### PR TITLE
fix: diff view buttons stays

### DIFF
--- a/src/webview/index.ts
+++ b/src/webview/index.ts
@@ -77,6 +77,9 @@ export async function showDiff({ leftContent, rightContent, leftPath, rightPath,
         setActiveDiffPanelWebview(extendsWebView);
       }
     });
+    panel.onDidDispose(() => {
+      setPanelFocused(false);
+    });
     // ugly, I know. The case is when opening new diff view, with the timeout, the new panel will wait fot the previous panel to set focus out
     setTimeout(() => {
       setPanelFocused(true);


### PR DESCRIPTION
Currently, once the diff view shown along with the top bar buttons (next / previous and swap) they are not been hidden even after the diff view closed by the user