### PR TITLE
Support gitlens & git-graph

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -14,7 +14,7 @@ export function getExplorerSides(leftPath: string, rightPath: string) {
   return { leftContent, rightContent };
 }
 
-export function getGitSides(path: string) {
+export function getGitSides(path: string, { ref }: { ref?: string } = {}) {
   const rootPath = getRootPath();
   let leftContent = '';
   let rightContent;
@@ -28,9 +28,12 @@ export function getGitSides(path: string) {
         .split(/\n/g)
         .includes(path);
 
-      const cmdGitDiff = `git diff -U100000 ${
-        isStaged ? '--cached' : ''
-      } -- ${path}`;
+      const cmdGitDiff = (
+        'git diff -U100000'
+        + (isStaged ? ' --cached' : '')
+        + (ref ? ` ${ref}` : '')
+        + ` -- ${path}`
+      );
       log(cmdGitDiff);
       patch = execSync(cmdGitDiff, cwdCommandOptions);
     } else if (isSvn()) {

--- a/src/externalExtensionsSupport.ts
+++ b/src/externalExtensionsSupport.ts
@@ -1,0 +1,31 @@
+import { Uri } from "vscode";
+
+const SUPPORTED_EXTENSIONS = ['gitlens', 'git-graph'];
+type SupportedExtensions = 'gitlens' | 'git-graph';
+
+export function isSupportedExtension(scheme: string): scheme is SupportedExtensions {
+    return SUPPORTED_EXTENSIONS.includes(scheme);
+}
+
+function decodeFromGitlensUri(uri: Uri): { ref: string, resourceUri: Uri } {
+    const gitlensInfo = JSON.parse(uri.query) as { ref: string };
+    return { ref: gitlensInfo.ref, resourceUri: Uri.file(uri.fsPath) };
+}
+
+function decodeFromGitGraphUri(uri: Uri): { ref: string, resourceUri: Uri } {
+    const gitGraphInfoBase64 = uri.query;
+    type GitGraphInfo = { commit: string, repo: string, filePath: string };
+    const gitGraphInfo = JSON.parse(Buffer.from(gitGraphInfoBase64, 'base64').toString()) as GitGraphInfo;
+    const path = Uri.joinPath(Uri.file(gitGraphInfo.repo), gitGraphInfo.filePath);
+    return { ref: gitGraphInfo.commit, resourceUri: path };
+}
+
+export function uriToGitInfo(extension: SupportedExtensions, uri: Uri): { ref: string, resourceUri: Uri } {
+    if (extension === 'gitlens') {
+        return decodeFromGitlensUri(uri);
+    } else if (extension === 'git-graph') {
+        return decodeFromGitGraphUri(uri);
+    } else {
+        throw new Error(`Unknown extension ${extension}`);
+    }
+}


### PR DESCRIPTION
This adds support for gitlens & git-graph via the toolbar button.
It should be possible to refactor this to support opening it directly from the gitlens view (not sure about git-graph as it's a webview).